### PR TITLE
Fixing some errors

### DIFF
--- a/src/OEBPS/content.opf
+++ b/src/OEBPS/content.opf
@@ -147,7 +147,6 @@
       <item id="som-15.9.html" href="som-15.9.html" media-type="application/xhtml+xml" />
       <item id="som-15.10.html" href="som-15.10.html" media-type="application/xhtml+xml" />
       <item id="som-15.11.html" href="som-15.11.html" media-type="application/xhtml+xml" />
-      <item id="som-16.10.html" href="som-16.10.html" media-type="application/xhtml+xml" />
       <item id="som-16.1.html" href="som-16.1.html" media-type="application/xhtml+xml" />
       <item id="som-16.2.html" href="som-16.2.html" media-type="application/xhtml+xml" />
       <item id="som-16.3.html" href="som-16.3.html" media-type="application/xhtml+xml" />
@@ -157,8 +156,7 @@
       <item id="som-16.7.html" href="som-16.7.html" media-type="application/xhtml+xml" />
       <item id="som-16.8.html" href="som-16.8.html" media-type="application/xhtml+xml" />
       <item id="som-16.9.html" href="som-16.9.html" media-type="application/xhtml+xml" />
-      <item id="som-17.10.html" href="som-17.10.html" media-type="application/xhtml+xml" />
-      <item id="som-17.11.html" href="som-17.11.html" media-type="application/xhtml+xml" />
+      <item id="som-16.10.html" href="som-16.10.html" media-type="application/xhtml+xml" />
       <item id="som-17.1.html" href="som-17.1.html" media-type="application/xhtml+xml" />
       <item id="som-17.2.html" href="som-17.2.html" media-type="application/xhtml+xml" />
       <item id="som-17.3.html" href="som-17.3.html" media-type="application/xhtml+xml" />
@@ -168,6 +166,8 @@
       <item id="som-17.7.html" href="som-17.7.html" media-type="application/xhtml+xml" />
       <item id="som-17.8.html" href="som-17.8.html" media-type="application/xhtml+xml" />
       <item id="som-17.9.html" href="som-17.9.html" media-type="application/xhtml+xml" />
+      <item id="som-17.10.html" href="som-17.10.html" media-type="application/xhtml+xml" />
+      <item id="som-17.11.html" href="som-17.11.html" media-type="application/xhtml+xml" />
       <item id="som-18.1.html" href="som-18.1.html" media-type="application/xhtml+xml" />
       <item id="som-18.2.html" href="som-18.2.html" media-type="application/xhtml+xml" />
       <item id="som-18.3.html" href="som-18.3.html" media-type="application/xhtml+xml" />
@@ -177,7 +177,6 @@
       <item id="som-18.7.html" href="som-18.7.html" media-type="application/xhtml+xml" />
       <item id="som-18.8.html" href="som-18.8.html" media-type="application/xhtml+xml" />
       <item id="som-18.9.html" href="som-18.9.html" media-type="application/xhtml+xml" />
-      <item id="som-19.10.html" href="som-19.10.html" media-type="application/xhtml+xml" />
       <item id="som-19.1.html" href="som-19.1.html" media-type="application/xhtml+xml" />
       <item id="som-19.2.html" href="som-19.2.html" media-type="application/xhtml+xml" />
       <item id="som-19.3.html" href="som-19.3.html" media-type="application/xhtml+xml" />
@@ -187,6 +186,7 @@
       <item id="som-19.7.html" href="som-19.7.html" media-type="application/xhtml+xml" />
       <item id="som-19.8.html" href="som-19.8.html" media-type="application/xhtml+xml" />
       <item id="som-19.9.html" href="som-19.9.html" media-type="application/xhtml+xml" />
+      <item id="som-19.10.html" href="som-19.10.html" media-type="application/xhtml+xml" />
       <item id="som-20.1.html" href="som-20.1.html" media-type="application/xhtml+xml" />
       <item id="som-20.2.html" href="som-20.2.html" media-type="application/xhtml+xml" />
       <item id="som-20.3.html" href="som-20.3.html" media-type="application/xhtml+xml" />
@@ -583,7 +583,6 @@
       <itemref idref="som-15.9.html" />
       <itemref idref="som-15.10.html" />
       <itemref idref="som-15.11.html" />
-      <itemref idref="som-16.10.html" />
       <itemref idref="som-16.1.html" />
       <itemref idref="som-16.2.html" />
       <itemref idref="som-16.3.html" />
@@ -593,8 +592,7 @@
       <itemref idref="som-16.7.html" />
       <itemref idref="som-16.8.html" />
       <itemref idref="som-16.9.html" />
-      <itemref idref="som-17.10.html" />
-      <itemref idref="som-17.11.html" />
+      <itemref idref="som-16.10.html" />
       <itemref idref="som-17.1.html" />
       <itemref idref="som-17.2.html" />
       <itemref idref="som-17.3.html" />
@@ -604,6 +602,8 @@
       <itemref idref="som-17.7.html" />
       <itemref idref="som-17.8.html" />
       <itemref idref="som-17.9.html" />
+      <itemref idref="som-17.10.html" />
+      <itemref idref="som-17.11.html" />
       <itemref idref="som-18.1.html" />
       <itemref idref="som-18.2.html" />
       <itemref idref="som-18.3.html" />
@@ -613,7 +613,6 @@
       <itemref idref="som-18.7.html" />
       <itemref idref="som-18.8.html" />
       <itemref idref="som-18.9.html" />
-      <itemref idref="som-19.10.html" />
       <itemref idref="som-19.1.html" />
       <itemref idref="som-19.2.html" />
       <itemref idref="som-19.3.html" />
@@ -623,6 +622,7 @@
       <itemref idref="som-19.7.html" />
       <itemref idref="som-19.8.html" />
       <itemref idref="som-19.9.html" />
+      <itemref idref="som-19.10.html" />
       <itemref idref="som-20.1.html" />
       <itemref idref="som-20.2.html" />
       <itemref idref="som-20.3.html" />

--- a/src/OEBPS/som-10.1.html
+++ b/src/OEBPS/som-10.1.html
@@ -23,7 +23,7 @@
     <p>
       Then he spread the eggs apart &mdash; before the child&#39;s eyes
       &mdash; and asked again if there were more eggs or more egg cups.</p>
-<img class="illus" src="./illus/ch10/10-2.png" class="illus"/>
+<img class="illus" src="./illus/ch10/10-2.png" />
 
     <p>
       One might try to explain this by supposing that older children are
@@ -33,7 +33,7 @@
       jars contained equal amounts of liquid. Then, before their eyes, he
       poured all the liquid from one of the short jars into the tall, thin
       one and asked which jar had more liquid now.</p>
-<img class="illus" src="./illus/ch10/10-3.png" class="illus"/>
+<img class="illus" src="./illus/ch10/10-3.png" />
 
     <p>
       These experiments have been repeated in many ways and in many

--- a/src/OEBPS/som-10.3.html
+++ b/src/OEBPS/som-10.3.html
@@ -36,7 +36,7 @@
       &mdash; more, less, and same! What could be done to settle this? The
       simplest theory is that the younger children have placed their
       agents in some <em>order of priority.</em></p>
-<img class="illus" src="./illus/ch10/10-5.png" class="illus"/>
+<img class="illus" src="./illus/ch10/10-5.png" />
 
     <p>
       Such a scheme can be extremely practical, since placing all the

--- a/src/OEBPS/som-10.5.html
+++ b/src/OEBPS/som-10.5.html
@@ -41,7 +41,7 @@
     <p>
       To solve the water jar problem, the Society-of-More would need other
       kinds of lower-level agents:</p>
-<img class="illus" src="./illus/ch10/10-8.png" class="illus"/>
+<img class="illus" src="./illus/ch10/10-8.png" />
 
     <p>
       You might complain that even if we needed these hordes of

--- a/src/OEBPS/som-10.9.html
+++ b/src/OEBPS/som-10.9.html
@@ -23,18 +23,18 @@
 
     <p>
       We could use this method to form our hierarchical Society-of-More:</p>
-<img class="illus" src="./illus/ch10/10-10.png" class="illus"/>
+<img class="illus" src="./illus/ch10/10-10.png" />
 
     <p>
       Now let&#39;s draw this in another form, as though there were no
       room to fit new agents in between the older ones.</p>
-<img class="illus" src="./illus/ch10/10-11.png" class="illus"/>
+<img class="illus" src="./illus/ch10/10-11.png" />
 
     <p>
       As we accumulate more low-level agents and additional intermediate
       layers to manage them, this grows into the very multilevel hierarchy
       we&#39;ve seen before.</p>
-<img class="illus" src="./illus/ch10/10-12.png" class="illus"/>
+<img class="illus" src="./illus/ch10/10-12.png" />
 
     <p>
       The nerve cells in an animal&#39;s brain can&#39;t always move aside

--- a/src/OEBPS/som-11.9.html
+++ b/src/OEBPS/som-11.9.html
@@ -29,7 +29,7 @@
       similar. This leads us into making false analogies. Consider how the
       pairs below, in which each self is neatly split into two parts, lead
       everyone to think they share some common unity.</p>
-<img class="illus" src="./illus/ch11/11-5.png" class="illus"/>
+<img class="illus" src="./illus/ch11/11-5.png" />
 
     <p>
       The items on the left are seen as neutrally objective and

--- a/src/OEBPS/som-12.1.html
+++ b/src/OEBPS/som-12.1.html
@@ -27,7 +27,7 @@
       structure that seems similar &mdash; except that Hand-Change
       disappears because you can&#39;t even push the car through it. Yet
       both structures fit the same description!</p>
-<img class="illus" src="./illus/ch12/12-2.png" class="illus"/>
+<img class="illus" src="./illus/ch12/12-2.png" />
 
     <p>
       But if Block-Arch causes Hand-Change, then this can&#39;t be a
@@ -41,13 +41,13 @@
       not suffice, because the child soon finds yet another structure that
       matches this description. Here, too, the Hand-Change phenomenon has
       disappeared; now you can push the car through it without letting go!</p>
-<img class="illus" src="./illus/ch12/12-3.png" class="illus"/>
+<img class="illus" src="./illus/ch12/12-3.png" />
 
     <p>
       Again we must change our description to keep this from being
       considered a Block-Arch. Finally the child discovers another
       variation that does produce Hand-Change:</p>
-<img class="illus" src="./illus/ch12/12-4.png" class="illus"/>
+<img class="illus" src="./illus/ch12/12-4.png" />
 
     <p>
       Our child has constructed for itself a useful conception of an arch,

--- a/src/OEBPS/som-12.4.html
+++ b/src/OEBPS/som-12.4.html
@@ -45,7 +45,7 @@
       together things we&#39;ve learned in different contexts. But how can
       one think in two different ways at once? By building, somewhere
       inside the mind, some arches of a different kind:</p>
-<img class="illus" src="./illus/ch12/12-7.png" class="illus"/>
+<img class="illus" src="./illus/ch12/12-7.png" />
 
     <p>
       Is that a foolish metaphor &mdash; to talk of building bridges

--- a/src/OEBPS/som-12.5.html
+++ b/src/OEBPS/som-12.5.html
@@ -50,7 +50,7 @@
       to wear it on our head. But with that knowledge we can do amazing
       things, like applying the concept of a chair to see how we could sit
       on a box, even though it has no legs or back!</p>
-<img class="illus" src="./illus/ch12/12-9.png" class="illus"/>
+<img class="illus" src="./illus/ch12/12-9.png" />
 
     <p>
       Uniframes that include structures like this can be powerful. For

--- a/src/OEBPS/som-12.6.html
+++ b/src/OEBPS/som-12.6.html
@@ -32,7 +32,7 @@
       horse, a stack of bricks, a rock. Even defining Arch has problems,
       since many things we recognize as arches just don&#39;t match our
       Block-Arch uniframe:</p>
-<img class="illus" src="./illus/ch12/12-11.png" class="illus"/>
+<img class="illus" src="./illus/ch12/12-11.png" />
 
     <p>
       All these shapes could be described as <em>shape with hole</em>

--- a/src/OEBPS/som-13.1.html
+++ b/src/OEBPS/som-13.1.html
@@ -24,7 +24,7 @@
       nor <em>the supports must not touch.</em> How could we make our
       minds perceive all these arches as the same? One way would be to
       draw this imaginary line:</p>
-<img class="illus" src="./illus/ch13/13-2.png" class="illus"/>
+<img class="illus" src="./illus/ch13/13-2.png" />
 
     <p>
       Now, suddenly, all those different arches fit one single frame

--- a/src/OEBPS/som-13.2.html
+++ b/src/OEBPS/som-13.2.html
@@ -28,7 +28,7 @@
     <p>
       However, we dealt with Tower-Arch by doing quite the opposite: we
       treated some real boundaries as though they did not exist:</p>
-    <img class="illus" src="./illus/ch13/13-4.png" class="illus"/>
+    <img class="illus" src="./illus/ch13/13-4.png" />
 
     <p>
       How cavalier a way to treat the world, to see three different things
@@ -43,7 +43,7 @@
       from nearer or farther, higher or lower, in a different color or
       shade of light, or against a different background. For example,
       consider these two appearances of the same table.</p>
-<img class="illus" src="./illus/ch13/13-5.png" class="illus"/>
+<img class="illus" src="./illus/ch13/13-5.png" />
 
     <p>
       Unless the mind could thus discard the aspects of each scene that

--- a/src/OEBPS/som-13.3.html
+++ b/src/OEBPS/som-13.3.html
@@ -27,14 +27,14 @@
       satisfy. For example, a child&#39;s <em>person-drawing</em>
       feature-network might consist of the following features and
       relations:</p>
-<img class="illus" src="./illus/ch13/13-7.png" class="illus"/>
+<img class="illus" src="./illus/ch13/13-7.png" />
 
     <p>
       To convert this description into an actual drawing, the child must
       employ some sort of <em>drawing procedure.</em> Here&#39;s one in
       which the process simply works its way down the feature list, like a
       little computer program:</p>
-<img class="illus" src="./illus/ch13/13-8.png" class="illus"/>
+<img class="illus" src="./illus/ch13/13-8.png" />
 
     <p>
       When the child starts to draw, the first item on the list

--- a/src/OEBPS/som-13.4.html
+++ b/src/OEBPS/som-13.4.html
@@ -31,7 +31,7 @@
       any change in the list of features and relations we used in the
       previous section. It would need only a small change in step 2 of our
       drawing procedure:</p>
-<img class="illus" src="./illus/ch13/13-10.png" class="illus"/>
+<img class="illus" src="./illus/ch13/13-10.png" />
 
     <p>
       This ensures that every feature mentioned in the list will be

--- a/src/OEBPS/som-13.5.html
+++ b/src/OEBPS/som-13.5.html
@@ -48,7 +48,7 @@
       draw each childish body-face. The <em>script</em> to the right shows
       only those steps that actually produce the lines of the drawing;
       this script has only half as many steps.</p>
-<img class="illus" src="./illus/ch13/13-12.png" class="illus"/>
+<img class="illus" src="./illus/ch13/13-12.png" />
 
     <p>
       The people we call <em>experts</em> seem to exercise their special

--- a/src/OEBPS/som-13.6.html
+++ b/src/OEBPS/som-13.6.html
@@ -24,13 +24,13 @@
       But when we ask the child to do the same repeatedly, we see a
       strange result. The top block suddenly grows shorter as it meets the
       edge of the long block!</p>
-<img class="illus" src="./illus/ch13/13-14.png" class="illus"/>
+<img class="illus" src="./illus/ch13/13-14.png" />
 
     <p>
       To understand what happened, just put yourself in the child&#39;s
       place.  You&#39;ve started to draw the upper edge of the short box,
       but how do you decide where to stop?</p>
-<img class="illus" src="./illus/ch13/13-15.png" class="illus"/>
+<img class="illus" src="./illus/ch13/13-15.png" />
 
     <p>
       Younger children don&#39;t yet possess much ability to draw lines in

--- a/src/OEBPS/som-14.1.html
+++ b/src/OEBPS/som-14.1.html
@@ -112,7 +112,7 @@
       are for keeping the tabletop itself away from the floor. A good way
       to understand that is to have a representation of what might happen
       if one of the table&#39;s legs failed to perform its function.</p>
-    <img class="illus" src="./illus/ch14/14-2.png" class="illus"/>
+    <img class="illus" src="./illus/ch14/14-2.png" />
 
     <p>
       To understand how something works, it helps to know how it can fail.</p>

--- a/src/OEBPS/som-14.2.html
+++ b/src/OEBPS/som-14.2.html
@@ -72,7 +72,7 @@
       Now, before you turn to the following page, try to solve this
       puzzle.</p>
 
-    <img class="illus" src="./illus/ch14/14-5.png" class="illus"/>
+    <img class="illus" src="./illus/ch14/14-5.png" />
 
 
 </body>

--- a/src/OEBPS/som-14.3.html
+++ b/src/OEBPS/som-14.3.html
@@ -29,7 +29,7 @@
       is, in the literal sense of <em>a rectangle with equal sides.</em>
       What makes us see so many different sorts of things as though they
       were squares?</p>
-    <img class="illus" src="./illus/ch14/14-7.png" class="illus"/>
+    <img class="illus" src="./illus/ch14/14-7.png" />
 
     <p>
       Some of these squares have no corners, others have no edges, and
@@ -48,7 +48,7 @@
     <p>
       It is tempting to assume that our visual processes work only in one
       direction, bringing information from the world into the mind:</p>
-    <img class="illus" src="./illus/ch14/14-8.png" class="illus"/>
+    <img class="illus" src="./illus/ch14/14-8.png" />
 
 
     <p>
@@ -56,6 +56,6 @@
       expect to see. Human vision must somehow combine the information
       that comes from the outer world with the structures in our memories.
       The situation must be more like this:</p>
-    <img class="illus" src="./illus/ch14/14-9.png" class="illus"/>
+    <img class="illus" src="./illus/ch14/14-9.png" />
 </body>
 </html>

--- a/src/OEBPS/som-14.6.html
+++ b/src/OEBPS/som-14.6.html
@@ -49,7 +49,7 @@
       two-dimensional, four-sided rectangle. This will let us continue to
       use our Block-Arch uniframe, together with that extra side to
       represent the floor.</p>
-    <img class="illus" src="./illus/ch14/14-12.png" class="illus"/>
+    <img class="illus" src="./illus/ch14/14-12.png" />
 
     <p>
       Why focus so sharply on the concept of a container? Because without

--- a/src/OEBPS/som-14.7.html
+++ b/src/OEBPS/som-14.7.html
@@ -39,7 +39,7 @@ situations without an outlet.
       at all &mdash; and that&#39;s what we mean by
       being <em>trapped.</em></p>
 
-    <img class="illus" src="./illus/ch14/14-14.png" class="illus"/>
+    <img class="illus" src="./illus/ch14/14-14.png" />
 
 
     <p>

--- a/src/OEBPS/som-14.8.html
+++ b/src/OEBPS/som-14.8.html
@@ -46,7 +46,7 @@
       and thinner than B, you couldn&#39;t be sure which one
       is <em>more.</em> An interaction-square array provides a convenient
       way to represent all the possible combinations:</p>
-    <img class="illus" src="./illus/ch14/14-16.png" class="illus"/>
+    <img class="illus" src="./illus/ch14/14-16.png" />
 
     <p>
       If square-arrays can represent how pairs of causes interact, could

--- a/src/OEBPS/som-16.3.html
+++ b/src/OEBPS/som-16.3.html
@@ -26,7 +26,7 @@
       special sensors and effectors designed to suit its specific
       needs. For example, the proto-specialist for Thirst might have a
       set of parts like these:</p>
-    <img class="illus" src="./illus/ch16/16-3.png" class="illus"/>
+    <img class="illus" src="./illus/ch16/16-3.png" />
 
     <p>
       It would not usually be practical to make an animal that way.  With
@@ -40,7 +40,7 @@
       freely. But most animals economize by having all their
       proto-specialists share common sets of organs for their interactions
       with the outer world.</p>
-    <img class="illus" src="./illus/ch16/16-4.png" class="illus"/>
+    <img class="illus" src="./illus/ch16/16-4.png" />
 
     <p>
       Another kind of economy comes from allowing the proto-specialists to

--- a/src/OEBPS/som-16.6.html
+++ b/src/OEBPS/som-16.6.html
@@ -33,7 +33,7 @@
       said, most real-world goals engage the same kinds of knowledge about
       the world. Wouldn&#39;t it be better if all those specialists could
       share a common, general-purpose memory?</p>
-    <img class="illus" src="./illus/ch16/16-8.png" class="illus"/>
+    <img class="illus" src="./illus/ch16/16-8.png" />
 
     <p>
       This would lead to problems, too. Whenever any specialist tried to

--- a/src/OEBPS/som-18.5.html
+++ b/src/OEBPS/som-18.5.html
@@ -50,7 +50,7 @@
       parking gear &mdash; go wrong at once. Parallel bundles and serial
       chains are only the simplest ways to link together various
       parts. Here are some others.</p>
-    <img class="illus" src="./illus/ch18/18-12.png" class="illus"/>
+    <img class="illus" src="./illus/ch18/18-12.png" />
     <p>
       Each serial connection makes a structure weaker, while each parallel
       connection makes it stronger.</p>

--- a/src/OEBPS/som-19.5.html
+++ b/src/OEBPS/som-19.5.html
@@ -46,7 +46,7 @@
       could form little <em>memorizers</em> next to the agencies that they
       affect.  Thus, memories are formed and stored close to the places
       where they are used.</p>
-    <img class="illus" src="./illus/ch19/19-3.png" class="illus"/>
+    <img class="illus" src="./illus/ch19/19-3.png" />
 
     <p>
       Can any simple scheme like this give rise to all the richness of the

--- a/src/OEBPS/som-19.6.html
+++ b/src/OEBPS/som-19.6.html
@@ -39,7 +39,7 @@
       chair is present. For example, we could make a chair-agent that
       becomes active whenever five or more of our six chair features are
       in sight:</p>
-    <img class="illus" src="./illus/ch19/19-5.png" class="illus"/>
+    <img class="illus" src="./illus/ch19/19-5.png" />
 
     <p>
       This scheme, too, will make mistakes. It will miss the chair if too

--- a/src/OEBPS/som-19.7.html
+++ b/src/OEBPS/som-19.7.html
@@ -39,7 +39,7 @@
       Papert and I proved mathematically that no feature-weighing machine
       can distinguish between the two kinds of patterns drawn below
       &mdash; no matter how cleverly we choose the weights.</p>
-<img class="illus" src="./illus/ch19/19-7.png" class="illus"/>
+<img class="illus" src="./illus/ch19/19-7.png" />
     <p>
       Both drawings on the left depict patterns that are connected &mdash;
       that is, that can be drawn with a single line. The patterns on the

--- a/src/OEBPS/som-19.9.html
+++ b/src/OEBPS/som-19.9.html
@@ -52,7 +52,7 @@
       processes. As we accumulate these recognizers, each agency will need
       a second kind of memory &mdash; a sort of recognition dictionary of
       recognizers to recognize its various states.</p>
-    <img class="illus" src="./illus/ch19/19-9.png" class="illus"/>
+    <img class="illus" src="./illus/ch19/19-9.png" />
 
     <p>
       This simple scheme can explain only a little of how we represent

--- a/src/OEBPS/som-20.3.html
+++ b/src/OEBPS/som-20.3.html
@@ -33,7 +33,7 @@
     <p>
       Sometimes no lower-level information can resolve an ambiguity
       &mdash; as in the case of this example by Oliver Selfridge.</p>
-    <img class="illus" src="./illus/ch20/20-2.png" class="illus"/>
+    <img class="illus" src="./illus/ch20/20-2.png" />
 
     <p>
       Here, there is no difference whatever between the H and the A, yet
@@ -45,7 +45,7 @@
       way. Thus, we recognize all these figures as similar, though no two
       of them are actually the same:</p>
 
-    <img class="illus" src="./illus/ch20/20-3.png" class="illus"/>
+    <img class="illus" src="./illus/ch20/20-3.png" />
 
 
     <p>

--- a/src/OEBPS/som-20.9.html
+++ b/src/OEBPS/som-20.9.html
@@ -30,7 +30,7 @@
       because a typical agent must both arouse other agents and be aroused
       by other agents, it must tend to branch both at its inputs and at
       its outputs. So our network can be drawn to look like this:</p>
-    <img class="illus" src="./illus/ch20/20-7.png" class="illus"/>
+    <img class="illus" src="./illus/ch20/20-7.png" />
 
     <p>
       When we represent the agents this way, we see that they can all be

--- a/src/OEBPS/som-21.3.html
+++ b/src/OEBPS/som-21.3.html
@@ -65,7 +65,7 @@
       have to do is replace each Trans-frame&#39;s Destination with the
       next one&#39;s Origin.</p>
 
-    <img class="illus" src="./illus/ch21/21-3.png" class="illus"/>
+    <img class="illus" src="./illus/ch21/21-3.png" />
 
 </body>
 </html>

--- a/src/OEBPS/som-24.3.html
+++ b/src/OEBPS/som-24.3.html
@@ -39,7 +39,7 @@
       more than a collection of AND-agents, one for each of the
       frame&#39;s pronome terminals! Then the entire frame for the New
       York trip would look like this:</p>
-    <img class="illus" src="./illus/ch24/24-2.png" class="illus"/>
+    <img class="illus" src="./illus/ch24/24-2.png" />
 
     <p>
       When a frame-agent is activated &mdash; either by seeing, hearing,

--- a/src/OEBPS/som-24.9.html
+++ b/src/OEBPS/som-24.9.html
@@ -35,7 +35,7 @@
       This suggests that not only frames but agencies in general might be
       organized in the form of agents sandwiched between recognizers and
       memorizers.</p>
-    <img class="illus" src="./illus/ch24/24-7.png" class="illus"/>
+    <img class="illus" src="./illus/ch24/24-7.png" />
 
     <p>
       This sketch of how our agencies are organized is

--- a/src/OEBPS/som-25.1.html
+++ b/src/OEBPS/som-25.1.html
@@ -28,7 +28,7 @@
       can&#39;t we see both forms at once? Because, it seems, our agencies
       can tolerate just one interpretation at a time.</p>
 
-    <img class="illus" src="./illus/ch25/25-2.png" class="illus"/>
+    <img class="illus" src="./illus/ch25/25-2.png" />
 
 
     <p>

--- a/src/OEBPS/som-25.2.html
+++ b/src/OEBPS/som-25.2.html
@@ -38,7 +38,7 @@
       Frame-Arrays. When we move, our vision-systems switch among a family
       of different frames that all use the same terminals.</p>
 
-    <img class="illus" src="./illus/ch25/25-4.png" class="illus"/>
+    <img class="illus" src="./illus/ch25/25-4.png" />
 
 
     <p>

--- a/src/OEBPS/som-26.2.html
+++ b/src/OEBPS/som-26.2.html
@@ -30,7 +30,7 @@
       since that&#39;s the most usual kind of gift for a child.</p>
 
     <img class="illus" src="./illus/ch26/26-2.png"/>
-    <img class="illus" src="./illus/ch26/26-3.png" class="illus"/>
+    <img class="illus" src="./illus/ch26/26-3.png" />
 
 
     <p>

--- a/src/OEBPS/som-29.2.html
+++ b/src/OEBPS/som-29.2.html
@@ -40,7 +40,7 @@
       in which the object need not actually move at all! Instead, what
       happens is the transfer of its ownership.</p>
 
-    <img class="illus" src="./illus/ch29/29-4.png" class="illus"/>
+    <img class="illus" src="./illus/ch29/29-4.png" />
 
 
     <p>
@@ -64,7 +64,7 @@
       certain parts of your mind become concerned with why she was so
       generous and how this involved her affections and obligations.</p>
 
-    <img class="illus" src="./illus/ch29/29-5.png" class="illus"/>
+    <img class="illus" src="./illus/ch29/29-5.png" />
 
 
     <p>

--- a/src/OEBPS/som-30.4.html
+++ b/src/OEBPS/som-30.4.html
@@ -56,7 +56,7 @@
       ourselves. We can regard what we learn about our models of the world
       as constituting our models of our models of the world.</p>
 
-    <img class="illus" src="./illus/ch30/30-3.png" class="illus"/>
+    <img class="illus" src="./illus/ch30/30-3.png" />
 
 </body>
 </html>

--- a/src/OEBPS/som-appendix.html
+++ b/src/OEBPS/som-appendix.html
@@ -295,7 +295,7 @@
       far apart, the signals from agents that detect similar trajectories
       converge on a common agency composed of evidence-weighing agents.</p>
 
-    <img class="illus" src="./illus/appendix/Appendix-2.png" class="illus"/>
+    <img class="illus" src="./illus/appendix/Appendix-2.png" />
 
 
     <p>
@@ -460,7 +460,7 @@
       to other regions of cells that lie farther away. Here is an
       idealized representation of this arrangement:</p>
 
-    <img class="illus" src="./illus/appendix/Appendix-3.png" class="illus"/>
+    <img class="illus" src="./illus/appendix/Appendix-3.png" />
 
 
     <p>
@@ -517,7 +517,7 @@
       agency. Here&#39;s one way embryonic cells could provide frameworks
       for future multilayered mind-societies:</p>
 
- <img class="illus" src="./illus/appendix/Appendix-4.png" class="illus"/>
+ <img class="illus" src="./illus/appendix/Appendix-4.png" />
 
     <p>
       Any agency that is potentially capable of expanding to assimilate a
@@ -525,7 +525,7 @@
       of cells could provide in any compact neighborhood. This must be why
       the cerebral cortex &mdash; the newest and largest portion of the
       brain &mdash; evolved its convoluted form.</p>
-    <img class="illus" src="./illus/appendix/Appendix-5.png" class="illus"/>
+    <img class="illus" src="./illus/appendix/Appendix-5.png" />
 
     <p>
       If the connections in the cortex of the brain develop this way,
@@ -813,7 +813,7 @@
       are directly descended from any of the others, but that they all
       share common ancestors, now long extinct.</p>
 
-    <img class="illus" src="./illus/appendix/Appendix-6.png" class="illus"/>
+    <img class="illus" src="./illus/appendix/Appendix-6.png" />
 
 
     <p>


### PR DESCRIPTION
Hello, thanks for the great repo! I have 2 changes:

* Some chapters orderings were wrong (x.10,x.11,... at the beginning due to alphabetical sorting I guess)
* Some `<img>` tags in some chapters had redundant `class="illus"` attribute. They were regarded by Apple's Books app as errors, causing the remainder of those chapters unrendered/inaccessible.

Wanted to share my fixes to save you/others the trouble. 

Cheers, 
Yigit